### PR TITLE
Fixed missing episode ids returned from calendar

### DIFF
--- a/trakt/calendar.py
+++ b/trakt/calendar.py
@@ -65,7 +65,7 @@ class Calendar(object):
             season = episode.get('episode', {}).get('season')
             ep = episode.get('episode', {}).get('number')
             e_data = {'airs_at': airs_date(episode.get('first_aired')),
-                      'episode_ids': episode.get('episode').get('ids'),
+                      'ids': episode.get('episode').get('ids'),
                       'title': episode.get('episode', {}).get('title')}
             self._calendar.append(TVEpisode(show, season, ep, **e_data))
         self._calendar = sorted(self._calendar, key=lambda x: x.airs_at)


### PR DESCRIPTION
Use "ids" instead of "episode_ids" as `utils.extract_ids` expects "ids" key.